### PR TITLE
Fix fallback decoding.

### DIFF
--- a/ircproto/connection.py
+++ b/ircproto/connection.py
@@ -10,16 +10,16 @@ from ircproto.replies import reply_templates
 class BaseIRCConnection(object):
     """Base class for IRC connection state machines."""
 
-    __slots__ = ('output_codec', 'input_decoder', 'fallback_decoder', '_input_buffer',
+    __slots__ = ('output_codec', 'input_codec', 'fallback_codec', '_input_buffer',
                  '_output_buffer', '_closed')
 
     sender = None  # type: str
 
     def __init__(self, output_encoding='utf-8', input_encoding='utf-8',
                  fallback_encoding='iso-8859-1'):
-        self.output_codec = codecs.getencoder(output_encoding)
-        self.input_decoder = codecs.getdecoder(input_encoding)
-        self.fallback_decoder = codecs.getdecoder(fallback_encoding)
+        self.output_codec = output_encoding
+        self.input_codec = input_encoding
+        self.fallback_codec = fallback_encoding
         self._input_buffer = bytearray()
         self._output_buffer = bytearray()
         self._closed = False
@@ -43,7 +43,7 @@ class BaseIRCConnection(object):
         self._input_buffer.extend(data)
         events = []
         while True:
-            event = decode_event(self._input_buffer, self.input_decoder, self.fallback_decoder)
+            event = decode_event(self._input_buffer, self.input_codec, self.fallback_codec)
             if event is None:
                 return events
             else:
@@ -99,7 +99,7 @@ class BaseIRCConnection(object):
             raise ProtocolError('the connection has been closed')
 
         encoded_event = event.encode()
-        self._output_buffer.extend(self.output_codec(encoded_event)[0])
+        self._output_buffer.extend(codecs.encode(encoded_event, encoding=self.output_codec))
 
 
 class IRCClientConnection(BaseIRCConnection):

--- a/ircproto/events.py
+++ b/ircproto/events.py
@@ -753,8 +753,7 @@ commands = {cls.command: cls for cls in locals().values()  # type: ignore
             if isinstance(cls, type) and issubclass(cls, Command)}
 
 
-def decode_event(buffer, decoder=codecs.getdecoder('utf-8'),
-                 fallback_decoder=codecs.getdecoder('iso-8859-1')):
+def decode_event(buffer, codec='utf-8', fallback_codec='iso-8859-1'):
     end_index = buffer.find(b'\r\n')
     if end_index == -1:
         return None
@@ -763,9 +762,9 @@ def decode_event(buffer, decoder=codecs.getdecoder('utf-8'),
         raise ProtocolError('received oversized message (%d bytes)' % (end_index + 2))
 
     try:
-        message = decoder(buffer[:end_index])[0]
+        message = codecs.decode(buffer[:end_index], encoding=codec)
     except UnicodeDecodeError:
-        message = fallback_decoder(buffer[:end_index], errors='replace')[0]
+        message = codecs.decode(buffer[:end_index], encoding=codec, errors='replace')
 
     del buffer[:end_index + 2]
 

--- a/ircproto/events.py
+++ b/ircproto/events.py
@@ -764,7 +764,7 @@ def decode_event(buffer, codec='utf-8', fallback_codec='iso-8859-1'):
     try:
         message = codecs.decode(buffer[:end_index], encoding=codec)
     except UnicodeDecodeError:
-        message = codecs.decode(buffer[:end_index], encoding=codec, errors='replace')
+        message = codecs.decode(buffer[:end_index], encoding=fallback_codec, errors='replace')
 
     del buffer[:end_index + 2]
 

--- a/ircproto/styles.py
+++ b/ircproto/styles.py
@@ -63,6 +63,7 @@ class IRCTextStyle(Enum):
     reverse = '\x16'
     plain = '\x0f'
 
+
 styles_re = re.compile('(\x03\d+(?:,\d+)?)|[\x02\x03\x1d\x1f\x16\x0f]')
 
 

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -14,3 +14,8 @@ def test_decode_event_unknown_command():
     buffer = bytearray(b':foo!bar@blah FROBNICATE\r\n')
     exc = pytest.raises(UnknownCommand, decode_event, buffer)
     assert str(exc.value) == 'IRC protocol violation: unknown command: FROBNICATE'
+
+
+def test_decode_fallback_conversion():
+    buffer = bytearray(b':foo!bar@blah PRIVMSG hey du\xe2\xa9k\r\n')
+    assert decode_event(buffer, codec='utf-8', fallback_codec='iso-8859-1')


### PR DESCRIPTION
The current logic for fallback decoding passes errors='replace' to the fallback decoder. Unfortunately not all decoder functions returned by codecs.getdecoder support this keyword argument and latin_1_decode, which is returned by codecs.getdecoder('iso-8859-1'), is such a function. The only reliable way to pass the errors kwarg is to call through codecs.decode. This patch rewrites all the encode/decode points to use codecs.encode and codecs.decode.