### PR TITLE
Fix fallback decoding

### DIFF
--- a/ircproto/events.py
+++ b/ircproto/events.py
@@ -765,7 +765,7 @@ def decode_event(buffer, decoder=codecs.getdecoder('utf-8'),
     try:
         message = decoder(buffer[:end_index])[0]
     except UnicodeDecodeError:
-        message = fallback_decoder(buffer[:end_index], errors='replace')[0]
+        message = fallback_decoder(buffer[:end_index], 'replace')[0]
 
     del buffer[:end_index + 2]
 

--- a/ircproto/styles.py
+++ b/ircproto/styles.py
@@ -63,6 +63,7 @@ class IRCTextStyle(Enum):
     reverse = '\x16'
     plain = '\x0f'
 
+
 styles_re = re.compile('(\x03\d+(?:,\d+)?)|[\x02\x03\x1d\x1f\x16\x0f]')
 
 

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,3 +1,5 @@
+import codecs
+
 import pytest
 
 from ircproto.events import decode_event
@@ -14,3 +16,10 @@ def test_decode_event_unknown_command():
     buffer = bytearray(b':foo!bar@blah FROBNICATE\r\n')
     exc = pytest.raises(UnknownCommand, decode_event, buffer)
     assert str(exc.value) == 'IRC protocol violation: unknown command: FROBNICATE'
+
+
+def test_decode_fallback_conversion():
+    decoder = codecs.getdecoder('utf-8')
+    fallback_decoder = codecs.getdecoder('iso-8859-1')
+    buffer = bytearray(b':foo!bar@blah PRIVMSG hey du\xe2\xa9k\r\n')
+    assert decode_event(buffer, decoder=decoder, fallback_decoder=fallback_decoder)


### PR DESCRIPTION
Decoder objects don't always take keyword arguments so use a positional instead.